### PR TITLE
Ruby 1.8.7 and Rails 2.3 compatible

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,61 +1,29 @@
 PATH
   remote: .
   specs:
-    recaptcha (4.6.6)
-      json
+    recaptcha (0.3.4)
+      json (~> 1.8.1)
+      rack (~> 1.4.7)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.5)
-      i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
-      minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
-      tzinfo (~> 1.1)
+    activesupport (2.3.18)
     addressable (2.3.8)
-    ast (2.3.0)
-    bump (0.5.3)
-    byebug (8.2.0)
-    coderay (1.1.0)
-    crack (0.4.2)
+    crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    hashdiff (0.2.3)
-    i18n (0.7.0)
+    hashdiff (0.3.5)
+    i18n (0.6.11)
     json (1.8.6)
-    maxitest (1.5.4)
-      minitest (>= 5.0.0, < 5.9.0)
     metaclass (0.0.4)
-    method_source (0.8.2)
-    minitest (5.8.3)
-    mocha (1.1.0)
+    minitest (5.11.3)
+    minitest-hooks (1.4.2)
+    mocha (1.4.0)
       metaclass (~> 0.0.1)
-    parser (2.3.1.2)
-      ast (~> 2.2)
-    powerpack (0.1.1)
-    pry (0.10.3)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-    pry-byebug (3.3.0)
-      byebug (~> 8.0)
-      pry (~> 0.10)
-    rainbow (2.1.0)
-    rake (10.4.2)
-    rubocop (0.40.0)
-      parser (>= 2.3.1.0, < 3.0)
-      powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.8.1)
+    rack (1.4.7)
+    rake (0.8.7)
     safe_yaml (1.0.4)
-    slop (3.6.0)
-    thread_safe (0.3.5)
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
-    unicode-display_width (1.0.5)
-    webmock (1.22.3)
+    webmock (1.24.6)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -64,16 +32,16 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport
-  bump
-  i18n
-  maxitest
+  activesupport (~> 2.3.10)
+  addressable (< 2.4.0)
+  hashdiff (< 0.3.6)
+  i18n (~> 0.6.11)
+  minitest (= 5.11.3)
+  minitest-hooks
   mocha
-  pry-byebug
-  rake
+  rake (~> 0.8.7)
   recaptcha!
-  rubocop
-  webmock
+  webmock (~> 1.24.6)
 
 BUNDLED WITH
-   1.16.1
+   1.15.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    recaptcha (0.3.4)
+    recaptcha (4.6.6.r187)
       json (~> 1.8.1)
       rack (~> 1.4.7)
 
@@ -36,9 +36,9 @@ DEPENDENCIES
   addressable (< 2.4.0)
   hashdiff (< 0.3.6)
   i18n (~> 0.6.11)
-  minitest (= 5.11.3)
-  minitest-hooks
-  mocha
+  minitest (~> 5.11.3)
+  minitest-hooks (~> 1.4.2)
+  mocha (~> 1.4.0)
   rake (~> 0.8.7)
   recaptcha!
   webmock (~> 1.24.6)

--- a/Rakefile
+++ b/Rakefile
@@ -1,15 +1,9 @@
 require "bundler/setup"
 require "bundler/gem_tasks"
 require "rake/testtask"
-require "bump/tasks"
 
 Rake::TestTask.new do |t|
   t.test_files = FileList['test/*_test.rb']
 end
 
-desc "rubocop"
-task :rubocop do
-  sh "rubocop --display-cop-names"
-end
-
-task default: [:test, :rubocop]
+task :default => :test

--- a/lib/recaptcha.rb
+++ b/lib/recaptcha.rb
@@ -3,6 +3,7 @@ require 'recaptcha/client_helper'
 require 'recaptcha/verify'
 require 'uri'
 require 'net/http'
+require 'rack/utils'
 
 module Recaptcha
   CONFIG = {
@@ -50,7 +51,7 @@ module Recaptcha
     else
       Net::HTTP
     end
-    query = URI.encode_www_form(verify_hash)
+    query = Rack::Utils.build_query(verify_hash)
     uri = URI.parse(Recaptcha.configuration.verify_url + '?' + query)
     http_instance = http.new(uri.host, uri.port)
     http_instance.read_timeout = http_instance.open_timeout = options[:timeout] || DEFAULT_TIMEOUT
@@ -61,7 +62,7 @@ module Recaptcha
 
   def self.i18n(key, default)
     if defined?(I18n)
-      I18n.translate(key, default: default)
+      I18n.translate(key, :default => default)
     else
       default
     end

--- a/lib/recaptcha/client_helper.rb
+++ b/lib/recaptcha/client_helper.rb
@@ -48,7 +48,7 @@ module Recaptcha
 
     # Invisible reCAPTCHA implementation
     def invisible_recaptcha_tags(options = {})
-      options = {callback: 'invisibleRecaptchaSubmit'}.merge options
+      options = { :callback => 'invisibleRecaptchaSubmit' }.merge(options)
       text = options.delete(:text)
       html, tag_attributes = Recaptcha::ClientHelper.recaptcha_components(options)
       html << recaptcha_default_callback if recaptcha_default_callback_required?(options)

--- a/lib/recaptcha/rails.rb
+++ b/lib/recaptcha/rails.rb
@@ -1,10 +1,5 @@
+require 'net/http'
 require 'recaptcha'
 
-module Recaptcha
-  class Railtie < Rails::Railtie
-    initializer :recaptcha do
-      ActionView::Base.send(:include, ::Recaptcha::ClientHelper)
-      ActionController::Base.send(:include, ::Recaptcha::Verify)
-    end
-  end
-end
+ActionView::Base.send(:include, Recaptcha::ClientHelper)
+ActionController::Base.send(:include, Recaptcha::Verify)

--- a/lib/recaptcha/railtie.rb
+++ b/lib/recaptcha/railtie.rb
@@ -1,0 +1,15 @@
+require 'net/http'
+require 'recaptcha'
+
+module Rails
+  module Recaptcha
+    class Railtie < Rails::Railtie
+      initializer "setup config" do
+        begin
+          ActionView::Base.send(:include, ::Recaptcha::ClientHelper)
+          ActionController::Base.send(:include, ::Recaptcha::Verify)
+        end
+      end
+    end
+  end
+end

--- a/lib/recaptcha/verify.rb
+++ b/lib/recaptcha/verify.rb
@@ -5,7 +5,7 @@ module Recaptcha
     # Your private API can be specified in the +options+ hash or preferably
     # using the Configuration.
     def verify_recaptcha(options = {})
-      options = {model: options} unless options.is_a? Hash
+      options = { :model => options } unless options.is_a? Hash
       return true if Recaptcha::Verify.skip?(options[:env])
 
       model = options[:model]

--- a/lib/recaptcha/version.rb
+++ b/lib/recaptcha/version.rb
@@ -1,3 +1,3 @@
 module Recaptcha
-  VERSION = "4.6.6".freeze
+  VERSION = "4.6.6.r187".freeze
 end

--- a/recaptcha.gemspec
+++ b/recaptcha.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", "~> 0.8.7"
   s.add_development_dependency "activesupport", "~> 2.3.10"
   s.add_development_dependency "i18n", "~> 0.6.11"
-  s.add_development_dependency "minitest", "= 5.11.3"
+  s.add_development_dependency "minitest", "~> 5.11.3"
   s.add_development_dependency "minitest-hooks", "~> 1.4.2"
   s.add_development_dependency "webmock", "~> 1.24.6"
   s.add_development_dependency "hashdiff", "< 0.3.6"

--- a/recaptcha.gemspec
+++ b/recaptcha.gemspec
@@ -8,18 +8,19 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/ambethia/recaptcha"
   s.summary     = s.description = "Helpers for the reCAPTCHA API"
   s.license     = "MIT"
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 1.8.7'
 
   s.files       = `git ls-files lib README.md CHANGELOG.md LICENSE`.split("\n")
 
-  s.add_runtime_dependency "json"
-  s.add_development_dependency "mocha"
-  s.add_development_dependency "rake"
-  s.add_development_dependency "activesupport"
-  s.add_development_dependency "i18n"
-  s.add_development_dependency "maxitest"
-  s.add_development_dependency "pry-byebug"
-  s.add_development_dependency "bump"
-  s.add_development_dependency "webmock"
-  s.add_development_dependency "rubocop"
+  s.add_runtime_dependency "json", "~> 1.8.1"
+  s.add_runtime_dependency "rack", "~> 1.4.7"
+  s.add_development_dependency "mocha", "~> 1.4.0"
+  s.add_development_dependency "rake", "~> 0.8.7"
+  s.add_development_dependency "activesupport", "~> 2.3.10"
+  s.add_development_dependency "i18n", "~> 0.6.11"
+  s.add_development_dependency "minitest", "= 5.11.3"
+  s.add_development_dependency "minitest-hooks", "~> 1.4.2"
+  s.add_development_dependency "webmock", "~> 1.24.6"
+  s.add_development_dependency "hashdiff", "< 0.3.6"
+  s.add_development_dependency "addressable", "< 2.4.0"
 end

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -1,4 +1,4 @@
-require_relative 'helper'
+require File.dirname(__FILE__) + '/helper'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/hash'
 
@@ -11,7 +11,7 @@ describe Recaptcha::ClientHelper do
 
   describe "noscript" do
     it "does not add noscript tags when noscript is given" do
-      recaptcha_tags(noscript: false).wont_include "noscript"
+      recaptcha_tags(:noscript => false).wont_include "noscript"
     end
 
     it "does not add noscript tags" do
@@ -20,7 +20,7 @@ describe Recaptcha::ClientHelper do
   end
 
   it "can include size" do
-    html = recaptcha_tags(size: 10)
+    html = recaptcha_tags(:size => 10)
     html.must_include("data-size=\"10\"")
   end
 
@@ -32,25 +32,25 @@ describe Recaptcha::ClientHelper do
   end
 
   it "includes id as div attribute" do
-    html = recaptcha_tags(id: 'my_id')
+    html = recaptcha_tags(:id => 'my_id')
     html.must_include(" id=\"my_id\"")
   end
 
   it "includes tabindex attribute" do
-    html = recaptcha_tags(tabindex: 123)
+    html = recaptcha_tags(:tabindex => 123)
     html.must_include(" data-tabindex=\"123\"")
   end
 
   it "does not include <script> tag when setting script: false" do
-    html = recaptcha_tags(script: false)
+    html = recaptcha_tags(:script => false)
     html.wont_include("<script")
   end
 
   it "adds :hl option to the url" do
-    html = recaptcha_tags(hl: 'en')
+    html = recaptcha_tags(:hl => 'en')
     html.must_include("?hl=en")
 
-    html = recaptcha_tags(hl: 'ru')
+    html = recaptcha_tags(:hl => 'ru')
     html.wont_include("?hl=en")
     html.must_include("?hl=ru")
 
@@ -64,7 +64,7 @@ describe Recaptcha::ClientHelper do
   end
 
   it "dasherizes the expired_callback attribute name" do
-    html = recaptcha_tags(expired_callback: 'my_expired_callback')
+    html = recaptcha_tags(:expired_callback => 'my_expired_callback')
     html.must_include(" data-expired-callback=\"my_expired_callback\"")
   end
 
@@ -81,22 +81,22 @@ describe Recaptcha::ClientHelper do
     end
 
     it "includes id as button attribute" do
-      html = invisible_recaptcha_tags(id: 'my_id')
+      html = invisible_recaptcha_tags(:id => 'my_id')
       html.must_include(" id=\"my_id\"")
     end
 
     it "does not include <script> tag when setting script: false" do
-      html = invisible_recaptcha_tags(script: false)
+      html = invisible_recaptcha_tags(:script => false)
       html.wont_include("<script")
     end
 
     it "renders other attributes" do
-      html = invisible_recaptcha_tags(foo_attr: 'foo_value')
+      html = invisible_recaptcha_tags(:foo_attr => 'foo_value')
       html.must_include(" foo_attr=\"foo_value\"")
     end
 
     it "renders other attributes when verification is disabled" do
-      html = invisible_recaptcha_tags(env: "test", foo_attr: 'foo_value')
+      html = invisible_recaptcha_tags(:env => "test", :foo_attr => 'foo_value')
       html.must_include(" foo_attr=\"foo_value\"")
     end
 
@@ -106,13 +106,13 @@ describe Recaptcha::ClientHelper do
     end
 
     it "doesn't render script tag when verification is disabled" do
-      html = invisible_recaptcha_tags(env: "test")
+      html = invisible_recaptcha_tags(:env => "test")
       html.wont_include("<script")
       html.wont_include("data-sitekey=")
     end
 
     it "doesn't include recaptcha attributes when verification is disabled" do
-      html = invisible_recaptcha_tags(env: "test")
+      html = invisible_recaptcha_tags(:env => "test")
       [:badge, :theme, :callback, :expired_callback, :size, :tabindex].each do |data_attribute|
         html.wont_include("#{data_attribute}=")
       end
@@ -124,7 +124,7 @@ describe Recaptcha::ClientHelper do
     end
 
     it "doesn't render default callback script if a callback is given" do
-      html = invisible_recaptcha_tags(callback: 'customCallback')
+      html = invisible_recaptcha_tags(:callback => 'customCallback')
       html.wont_include("var invisibleRecaptchaSubmit")
     end
   end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,4 +1,4 @@
-require_relative 'helper'
+require File.dirname(__FILE__) + '/helper'
 
 describe Recaptcha::Configuration do
   describe "#api_server_url" do
@@ -9,7 +9,7 @@ describe Recaptcha::Configuration do
     describe "when api_server_url is overwritten" do
       it "serves the overwritten url" do
         proxied_api_server_url = 'https://127.0.0.1:8080/recaptcha/api.js'
-        Recaptcha.with_configuration(api_server_url: proxied_api_server_url) do
+        Recaptcha.with_configuration(:api_server_url => proxied_api_server_url) do
           Recaptcha.configuration.api_server_url.must_equal proxied_api_server_url
         end
       end
@@ -24,7 +24,7 @@ describe Recaptcha::Configuration do
     describe "when api_server_url is overwritten" do
       it "serves the overwritten url" do
         proxied_verify_url = 'https://127.0.0.1:8080/recaptcha/api/siteverify'
-        Recaptcha.with_configuration(verify_url: proxied_verify_url) do
+        Recaptcha.with_configuration(:verify_url => proxied_verify_url) do
           Recaptcha.configuration.verify_url.must_equal proxied_verify_url
         end
       end
@@ -35,7 +35,7 @@ describe Recaptcha::Configuration do
     outside = '0000000000000000000000000000000000000000'
     Recaptcha.configuration.site_key.must_equal outside
 
-    Recaptcha.with_configuration(site_key: '12345') do
+    Recaptcha.with_configuration(:site_key => '12345') do
       Recaptcha.configuration.site_key.must_equal '12345'
     end
 
@@ -46,7 +46,7 @@ describe Recaptcha::Configuration do
     before = Recaptcha.configuration.site_key.dup
 
     assert_raises NoMemoryError do
-      Recaptcha.with_configuration(site_key: '12345') do
+      Recaptcha.with_configuration(:site_key => '12345') do
         Recaptcha.configuration.site_key.must_equal '12345'
         raise NoMemoryError, "an exception"
       end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,6 @@
 require 'bundler/setup'
-require 'maxitest/autorun'
+require 'minitest/autorun'
+require 'minitest/hooks/default'
 require 'mocha/setup'
 require 'webmock/minitest'
 require 'cgi'
@@ -11,7 +12,7 @@ ENV.delete('RACK_ENV')
 
 I18n.enforce_available_locales = false
 
-Minitest::Test.send(:prepend, Module.new do
+Minitest::Test.send(:include, Module.new do
   def setup
     super
     Recaptcha.configure do |config|

--- a/test/verify_test.rb
+++ b/test/verify_test.rb
@@ -1,9 +1,9 @@
-require_relative 'helper'
+require File.dirname(__FILE__) + '/helper'
 
 describe Recaptcha::Verify do
   before do
     @controller = TestController.new
-    @controller.request = stub(remote_ip: "1.1.1.1", format: :html)
+    @controller.request = stub(:remote_ip => "1.1.1.1", :format => :html)
 
     @expected_post_data = {}
     @expected_post_data["remoteip"]   = @controller.request.remote_ip
@@ -34,7 +34,7 @@ describe Recaptcha::Verify do
   describe "#verify_recaptcha" do
     it "returns true on success" do
       @controller.flash[:recaptcha_error] = "previous error that should be cleared"
-      expect_http_post.to_return(body: '{"success":true}')
+      expect_http_post.to_return(:body => '{"success":true}')
 
       assert @controller.verify_recaptcha
       assert_nil @controller.flash[:recaptcha_error]
@@ -48,29 +48,29 @@ describe Recaptcha::Verify do
     end
 
     it "returns false when secret key is invalid" do
-      expect_http_post.to_return(body: %({"foo":"false", "bar":"invalid-site-secret-key"}))
+      expect_http_post.to_return(:body => %({"foo":"false", "bar":"invalid-site-secret-key"}))
 
       refute @controller.verify_recaptcha
       assert_equal "reCAPTCHA verification failed, please try again.", @controller.flash[:recaptcha_error]
     end
 
     it "adds an error to the model" do
-      expect_http_post.to_return(body: %({"foo":"false", "bar":"bad-news"}))
+      expect_http_post.to_return(:body => %({"foo":"false", "bar":"bad-news"}))
 
       errors = mock
       errors.expects(:add).with(:base, "reCAPTCHA verification failed, please try again.")
-      model = mock(errors: errors)
+      model = mock(:errors => errors)
 
-      refute @controller.verify_recaptcha(model: model)
+      refute @controller.verify_recaptcha(:model => model)
       assert_nil @controller.flash[:recaptcha_error]
     end
 
     it "returns true on success with optional key" do
       key = 'ADIFFERENTPRIVATEKEYXXXXXXXXXXXXXX'
       @controller.flash[:recaptcha_error] = "previous error that should be cleared"
-      expect_http_post(secret_key: key).to_return(body: '{"success":true}')
+      expect_http_post(key).to_return(:body => '{"success":true}')
 
-      assert @controller.verify_recaptcha(secret_key: key)
+      assert @controller.verify_recaptcha(:secret_key => key)
       assert_nil @controller.flash[:recaptcha_error]
     end
 
@@ -80,9 +80,9 @@ describe Recaptcha::Verify do
       stub_request(
         :get,
         "https://www.google.com/recaptcha/api/siteverify?response=string&secret=#{secret_key}"
-      ).to_return(body: '{"success":true}')
+      ).to_return(:body => '{"success":true}')
 
-      assert @controller.verify_recaptcha(skip_remote_ip: true)
+      assert @controller.verify_recaptcha(:skip_remote_ip => true)
       assert_nil @controller.flash[:recaptcha_error]
     end
 
@@ -95,7 +95,7 @@ describe Recaptcha::Verify do
     end
 
     it "blows up on timeout when graceful is disabled" do
-      Recaptcha.with_configuration(handle_timeouts_gracefully: false) do
+      Recaptcha.with_configuration(:handle_timeouts_gracefully => false) do
         expect_http_post.to_timeout
         assert_raises Recaptcha::RecaptchaError, "Recaptcha unreachable." do
           assert @controller.verify_recaptcha
@@ -110,16 +110,16 @@ describe Recaptcha::Verify do
       verification_failed_default      = "reCAPTCHA verification failed, please try again."
 
       I18n.expects(:translate).
-        with('recaptcha.errors.verification_failed', default: verification_failed_default).
+        with('recaptcha.errors.verification_failed', :default => verification_failed_default).
         returns(verification_failed_translated)
 
       errors = mock
       errors.expects(:add).with(:base, verification_failed_translated)
       model = mock
-      model.stubs(errors: errors)
+      model.stubs(:errors => errors)
 
-      expect_http_post.to_return(body: %({"foo":"false", "bar":"bad-news"}))
-      @controller.verify_recaptcha(model: model)
+      expect_http_post.to_return(:body => %({"foo":"false", "bar":"bad-news"}))
+      @controller.verify_recaptcha(:model => model)
     end
 
     it "uses I18n for the timeout message" do
@@ -128,23 +128,23 @@ describe Recaptcha::Verify do
       recaptcha_unreachable_default    = "Oops, we failed to validate your reCAPTCHA response. Please try again."
 
       I18n.expects(:translate).
-        with('recaptcha.errors.recaptcha_unreachable', default: recaptcha_unreachable_default).
+        with('recaptcha.errors.recaptcha_unreachable', :default => recaptcha_unreachable_default).
         returns(recaptcha_unreachable_translated)
 
       errors = mock
       errors.expects(:add).with(:base, recaptcha_unreachable_translated)
       model = mock
-      model.stubs(errors: errors)
+      model.stubs(:errors => errors)
 
       expect_http_post.to_timeout
-      @controller.verify_recaptcha(model: model)
+      @controller.verify_recaptcha(:model => model)
     end
 
     it "translates api response with I18n" do
       api_error_translated = "Bad news, body :("
-      expect_http_post.to_return(body: %({"foo":"false", "bar":"bad-news"}))
+      expect_http_post.to_return(:body => %({"foo":"false", "bar":"bad-news"}))
       I18n.expects(:translate).
-        with('recaptcha.errors.verification_failed', default: 'reCAPTCHA verification failed, please try again.').
+        with('recaptcha.errors.verification_failed', :default => 'reCAPTCHA verification failed, please try again.').
         returns(api_error_translated)
 
       refute @controller.verify_recaptcha
@@ -152,15 +152,15 @@ describe Recaptcha::Verify do
     end
 
     it "falls back to api response if i18n translation is missing" do
-      expect_http_post.to_return(body: %({"foo":"false", "bar":"bad-news"}))
+      expect_http_post.to_return(:body => %({"foo":"false", "bar":"bad-news"}))
 
       refute @controller.verify_recaptcha
       assert_equal "reCAPTCHA verification failed, please try again.", @controller.flash[:recaptcha_error]
     end
 
     it "does not flash error when request was not html" do
-      @controller.request = stub(remote_ip: "1.1.1.1", format: :json)
-      expect_http_post.to_return(body: %({"foo":"false", "bar":"bad-news"}))
+      @controller.request = stub(:remote_ip => "1.1.1.1", :format => :json)
+      expect_http_post.to_return(:body => %({"foo":"false", "bar":"bad-news"}))
       refute @controller.verify_recaptcha
       assert_nil @controller.flash[:recaptcha_error]
     end
@@ -176,44 +176,44 @@ describe Recaptcha::Verify do
       let(:hostname) { 'fake.hostname.com' }
 
       before do
-        expect_http_post.to_return(body: %({"success":true, "hostname": "#{hostname}"}))
+        expect_http_post.to_return(:body => %({"success":true, "hostname": "#{hostname}"}))
       end
 
       it "passes with nil" do
-        assert @controller.verify_recaptcha(hostname: nil)
+        assert @controller.verify_recaptcha(:hostname => nil)
         assert_nil @controller.flash[:recaptcha_error]
       end
 
       it "passes with false" do
-        assert @controller.verify_recaptcha(hostname: false)
+        assert @controller.verify_recaptcha(:hostname => false)
         assert_nil @controller.flash[:recaptcha_error]
       end
 
       it "check for equality when string custom hostname validation is passed" do
-        assert @controller.verify_recaptcha(hostname: hostname)
+        assert @controller.verify_recaptcha(:hostname => hostname)
         assert_nil @controller.flash[:recaptcha_error]
       end
 
       it "fails when custom hostname validation does not match" do
-        expect_http_post.to_return(body: %({"success":true, "hostname": "not_#{hostname}"}))
+        expect_http_post.to_return(:body => %({"success":true, "hostname": "not_#{hostname}"}))
 
-        refute @controller.verify_recaptcha(hostname: hostname)
+        refute @controller.verify_recaptcha(:hostname => hostname)
         assert_equal "reCAPTCHA verification failed, please try again.", @controller.flash[:recaptcha_error]
       end
 
       it "check with call when callable custom hostname validation is passed" do
-        assert @controller.verify_recaptcha(hostname: -> (d) { d == hostname })
+        assert @controller.verify_recaptcha(:hostname => Proc.new { |d| d == hostname } )
         assert_nil @controller.flash[:recaptcha_error]
       end
 
       it "raises when invalid custom hostname validation is passed" do
         assert_raises Recaptcha::RecaptchaError do
-          @controller.verify_recaptcha(hostname: 0)
+          @controller.verify_recaptcha(:hostname => 0)
         end
       end
 
       describe "when default hostname validation matches" do
-        around { |test| Recaptcha.with_configuration(hostname: hostname, &test) }
+        around { |&test| Recaptcha.with_configuration(:hostname => hostname, &test) }
 
         it "passes" do
           assert @controller.verify_recaptcha
@@ -221,13 +221,13 @@ describe Recaptcha::Verify do
         end
 
         it "fails when custom validation does not match" do
-          refute @controller.verify_recaptcha(hostname: "not_#{hostname}")
+          refute @controller.verify_recaptcha(:hostname => "not_#{hostname}")
           assert_equal "reCAPTCHA verification failed, please try again.", @controller.flash[:recaptcha_error]
         end
       end
 
       describe "when default hostname validation does not match" do
-        around { |test| Recaptcha.with_configuration(hostname: "not_#{hostname}", &test) }
+        around { |&test| Recaptcha.with_configuration(:hostname => "not_#{hostname}", &test) }
 
         it "fails" do
           refute @controller.verify_recaptcha
@@ -235,7 +235,7 @@ describe Recaptcha::Verify do
         end
 
         it "passes when custom validation matches" do
-          assert @controller.verify_recaptcha(hostname: hostname)
+          assert @controller.verify_recaptcha(:hostname => hostname)
           assert_nil @controller.flash[:recaptcha_error]
         end
       end
@@ -253,7 +253,7 @@ describe Recaptcha::Verify do
     end
   end
 
-  def expect_http_post(secret_key: Recaptcha.configuration.secret_key)
+  def expect_http_post(secret_key = Recaptcha.configuration.secret_key)
     stub_request(
       :get,
       "https://www.google.com/recaptcha/api/siteverify?remoteip=1.1.1.1&response=string&secret=#{secret_key}"


### PR DESCRIPTION
Biggest functional change was to use `Rack::Utils.build_query` instead of `URI.encode_www_form`

Not really huge changes, but working now.
Had to update test libraries, and lost some utilities like `rubocop` and `bump`.

